### PR TITLE
Mission namespace vars to global, surface/building fixes

### DIFF
--- a/hatg/addons/functions/CfgFunctions.hpp
+++ b/hatg/addons/functions/CfgFunctions.hpp
@@ -22,6 +22,7 @@ class CfgFunctions
         class debug 
         {
             file = QPATHTOFOLDER(functions\debug);
+            class batchTesting {};
             class isDebug {};
             class log {};
         };

--- a/hatg/addons/functions/functions/cba/fn_settings.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings.sqf
@@ -18,7 +18,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_debug", _value, true];
+        // missionNamespace setVariable ["hatg_setting_debug", _value, true];
+        hatg_setting_debug = _value;
+        publicVariable "hatg_setting_debug";
     }
 ] call CBA_fnc_addSetting;
 
@@ -32,7 +34,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_debug_surface", _value, true];
+        // missionNamespace setVariable ["hatg_setting_debug_surface", _value, true];
+        hatg_setting_debug_surface = _value;
+        publicVariable "hatg_setting_debug_surface";
     }
 ] call CBA_fnc_addSetting;
 
@@ -46,7 +50,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_debug_conditions", _value, true];
+        // missionNamespace setVariable ["hatg_setting_debug_conditions", _value, true];
+        hatg_setting_debug_conditions = _value;
+        publicVariable "hatg_setting_debug_conditions";
     }
 ] call CBA_fnc_addSetting;
 
@@ -60,6 +66,8 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_debug_detection", _value, true];
+        // missionNamespace setVariable ["hatg_setting_debug_detection", _value, true];
+        hatg_setting_debug_detection = _value;
+        publicVariable "hatg_setting_debug_detection";
     }
 ] call CBA_fnc_addSetting;

--- a/hatg/addons/functions/functions/cba/fn_settings_detection.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings_detection.sqf
@@ -13,7 +13,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_surfaces", _value, true];
+        // missionNamespace setVariable ["hatg_setting_surfaces", _value, true];
+        hatg_setting_surfaces = _value;
+        publicVariable "hatg_setting_surfaces";
     }
 ] call CBA_fnc_addSetting;
 
@@ -27,7 +29,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_building", _value, true];
+        // missionNamespace setVariable ["hatg_setting_building", _value, true];
+        hatg_setting_building = _value;
+        publicVariable "hatg_setting_building";
     }
 ] call CBA_fnc_addSetting;
 
@@ -41,7 +45,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_cooldown", round(_value), true];
+        // missionNamespace setVariable ["hatg_setting_cooldown", round(_value), true];
+        hatg_setting_cooldown = _value;
+        publicVariable "hatg_setting_cooldown";
     }
 ] call CBA_fnc_addSetting;
 
@@ -55,7 +61,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_distance_close", round(_value), true];
+        // missionNamespace setVariable ["hatg_setting_distance_close", round(_value), true];
+        hatg_setting_distance_close = _value;
+        publicVariable "hatg_setting_distance_close";
     }
 ] call CBA_fnc_addSetting;
 
@@ -69,7 +77,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_distance_height", round(_value), true];
+        // missionNamespace setVariable ["hatg_setting_distance_height", round(_value), true];
+        hatg_setting_distance_height = _value;
+        publicVariable "hatg_setting_distance_height";
     }
 ] call CBA_fnc_addSetting;
 
@@ -83,7 +93,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_distance_close_multiplier", _value, true];
+        // missionNamespace setVariable ["hatg_setting_distance_close_multiplier", _value, true];
+        hatg_setting_distance_close_multiplier = _value;
+        publicVariable "hatg_setting_distance_close_multiplier";
     }
 ] call CBA_fnc_addSetting;
 
@@ -97,7 +109,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_distance_reset", round(_value), true];
+        // missionNamespace setVariable ["hatg_setting_distance_reset", round(_value), true];
+        hatg_setting_distance_reset = _value;
+        publicVariable "hatg_setting_distance_reset";
     }
 ] call CBA_fnc_addSetting;
 
@@ -111,7 +125,9 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_distance_shots", round(_value), true];
+        // missionNamespace setVariable ["hatg_setting_distance_shots", round(_value), true];
+        hatg_setting_distance_shots = _value;
+        publicVariable "hatg_setting_distance_shots";
     }
 ] call CBA_fnc_addSetting;
 
@@ -125,6 +141,8 @@
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_movement_crouch", _value, true];
+        // missionNamespace setVariable ["hatg_setting_movement_crouch", _value, true];
+        hatg_setting_movement_crouch = _value;
+        publicVariable "hatg_setting_movement_crouch";
     }
 ] call CBA_fnc_addSetting;

--- a/hatg/addons/functions/functions/cba/fn_settings_equipment.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings_equipment.sqf
@@ -21,7 +21,9 @@ private _defaultGhilliesBlacklist = str(_defaultGhillies#1);
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_equipment_suppressor_whitelist", _value, true];
+        // missionNamespace setVariable ["hatg_setting_equipment_suppressor_whitelist", _value, true];
+        hatg_setting_equipment_suppressor_whitelist = _value;
+        publicVariable "hatg_setting_equipment_suppressor_whitelist";
     }
 ] call CBA_fnc_addSetting;
 
@@ -35,7 +37,9 @@ private _defaultGhilliesBlacklist = str(_defaultGhillies#1);
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_equipment_suppressor_blacklist", _value, true];
+        // missionNamespace setVariable ["hatg_setting_equipment_suppressor_blacklist", _value, true];
+        hatg_setting_equipment_suppressor_blacklist = _value;
+        publicVariable "hatg_setting_equipment_suppressor_blacklist";
     }
 ] call CBA_fnc_addSetting;
 
@@ -49,7 +53,9 @@ private _defaultGhilliesBlacklist = str(_defaultGhillies#1);
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_equipment_suppressor_integral", _value, true];
+        // missionNamespace setVariable ["hatg_setting_equipment_suppressor_integral", _value, true];
+        hatg_setting_equipment_suppressor_integral = _value;
+        publicVariable "hatg_setting_equipment_suppressor_integral";
     }
 ] call CBA_fnc_addSetting;
 
@@ -63,7 +69,9 @@ private _defaultGhilliesBlacklist = str(_defaultGhillies#1);
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_equipment_ghillie_whitelist", _value, true];
+        // missionNamespace setVariable ["hatg_setting_equipment_ghillie_whitelist", _value, true];
+        hatg_setting_equipment_ghillie_whitelist = _value;
+        publicVariable "hatg_setting_equipment_ghillie_whitelist";
     }
 ] call CBA_fnc_addSetting;
 
@@ -77,6 +85,8 @@ private _defaultGhilliesBlacklist = str(_defaultGhillies#1);
     {
         params ["_value"];
 
-        missionNamespace setVariable ["hatg_setting_equipment_ghillie_blacklist", _value, true];
+        // missionNamespace setVariable ["hatg_setting_equipment_ghillie_blacklist", _value, true];
+        hatg_setting_equipment_ghillie_blacklist = _value;
+        publicVariable "hatg_setting_equipment_ghillie_blacklist";
     }
 ] call CBA_fnc_addSetting;

--- a/hatg/addons/functions/functions/cba/fn_settings_ui.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings_ui.sqf
@@ -12,7 +12,7 @@
     {
         params ["_value"];
 
-        uiNamespace setVariable ["hatg_setting_ui", _value];
+        // uiNamespace setVariable ["hatg_setting_ui", _value];
     }
 ] call CBA_fnc_addSetting;
 
@@ -22,11 +22,11 @@
     ["$STR_HATG_UI_Enable_Fading", "$STR_HATG_UI_Enable_Fading_info"],
     SETTING_HEADER_UI, 
     [0, 15, 0, 0],
-    1,
+    2,
     {
         params ["_value"];
 
-        uiNamespace setVariable ["hatg_setting_ui_fade", round (_value)];
+        // uiNamespace setVariable ["hatg_setting_ui_fade", round (_value)];
     }
 ] call CBA_fnc_addSetting;
 
@@ -42,7 +42,7 @@ private _fontNames = ["PuristaBold", "PuristaLight", "PuristaMedium", "PuristaSe
         params ["_value"];
 
 
-        missionNamespace setVariable ["hatg_setting_ui_font", _value, true];
+        // uiNamespace setVariable ["hatg_setting_ui_font", _value, true];
     }
 ] call CBA_fnc_addSetting;
 
@@ -86,7 +86,7 @@ private _fontNames = ["PuristaBold", "PuristaLight", "PuristaMedium", "PuristaSe
     {
         params["_value"];
 
-        uiNamespace setVariable ["hatg_setting_ui_textsize", _value];
+        // uiNamespace setVariable ["hatg_setting_ui_textsize", _value];
     }
 ] call CBA_fnc_addSetting;
 
@@ -100,7 +100,7 @@ private _fontNames = ["PuristaBold", "PuristaLight", "PuristaMedium", "PuristaSe
     {
         params ["_value"];
 
-        uiNamespace setVariable ["hatg_setting_ui_colour_hidden", _value];
+        // uiNamespace setVariable ["hatg_setting_ui_colour_hidden", _value];
     }
 ] call CBA_fnc_addSetting;
 
@@ -114,6 +114,6 @@ private _fontNames = ["PuristaBold", "PuristaLight", "PuristaMedium", "PuristaSe
     {
         params ["_value"];
 
-        uiNamespace setVariable ["hatg_setting_ui_colour_revealed", _value];
+        // uiNamespace setVariable ["hatg_setting_ui_colour_revealed", _value];
     }
 ] call CBA_fnc_addSetting;

--- a/hatg/addons/functions/functions/conditions/fn_canStayHidden.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_canStayHidden.sqf
@@ -1,6 +1,6 @@
 params ["_unit", "_unitShots"];
 
-private _allowedShots = ["hatg_setting_distance_shots", -1] call HATG_fnc_getVariable;
+private _allowedShots = hatg_setting_distance_shots;
 
 private _hasGhillie = [_unit] call HATG_fnc_hasGhillie;
 private _hasSuppressor = [_unit] call HATG_fnc_hasSuppressor;

--- a/hatg/addons/functions/functions/conditions/fn_getNearbyUnits.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_getNearbyUnits.sqf
@@ -10,8 +10,8 @@
         _stance <STRING>
     
     Dependencies:
-        missionNamespace variables:
-        > "hatg_setting_distance_close" <INT>
+        global variables:
+        > hatg_setting_distance_close <INT>
     
     Usage:
         [player] call HATG_fnc_getNearbyUnits;
@@ -25,8 +25,8 @@ params ["_unit", ["_stance", "PRONE"]];
 private _unitSide = side _unit;
 
 private _distanceNearby = 100;
-private _distanceClose = ["hatg_setting_distance_close", -1] call HATG_fnc_getVariable;
-private _distanceCloseMultiplier = ["hatg_setting_distance_close_multiplier", -1] call HATG_fnc_getVariable;
+private _distanceClose = hatg_setting_distance_close;
+private _distanceCloseMultiplier = hatg_setting_distance_close_multiplier;
 
 // Can't think of a better way to do these if statements, there will be a more efficient way. Brain doesn't brain rn
 if (_stance == "CROUCH") then {

--- a/hatg/addons/functions/functions/conditions/fn_isInBuilding.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_isInBuilding.sqf
@@ -9,7 +9,7 @@
         _unit <OBJECT>
     
     Dependencies:
-        N/A
+        hatg_setting_building <BOOL>
     
     Usage:
         [player] call HATG_fnc_isInBuilding;

--- a/hatg/addons/functions/functions/conditions/fn_isOnFloor.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_isOnFloor.sqf
@@ -1,6 +1,6 @@
 params ["_unit"];
 
-private _allowedHeight = ["hatg_setting_distance_height", 2] call HATG_fnc_getVariable;
+private _allowedHeight = hatg_setting_distance_height;
 
 if (_allowedHeight isEqualTo -1) exitWith {true};
 

--- a/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
@@ -29,8 +29,11 @@ private _surfaceTexture = toLowerANSI (surfaceTexture _pos);
 [_surface, 2, _fnc_scriptName] call HATG_fnc_log;
 [_surfaceTexture, 2, _fnc_scriptName] call HATG_fnc_log;
 
+private _surfacesNames = ["grass", "forest", "thorn", "field", "hlina", "trava"];
+
 if !(hatg_setting_surfaces) exitWith {true}; // If the setting to ignore surfaces is off, return true
 if ([_unit] call HATG_fnc_isInBuilding) exitWith {true};
-if ("grass" in _surface || {"grass" in _surfaceTexture}) exitWith {true};
+if (nearestTerrainObjects [_unit, ["bush"], 3, false, true] isNotEqualTo []) exitWith {true};
+if (_surfacesNames findIf {_x in _surface || {_x in _surfaceTexture}} isNotEqualTo -1) exitWith {true};
 
 false;

--- a/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
@@ -9,7 +9,7 @@
         _unit <OBJECT>
     
     Dependencies:
-        N/A
+        hatg_setting_surfaces <BOOL>
     
     Usage:
         [player] call HATG_fnc_surfaceIsGrass;
@@ -29,7 +29,7 @@ private _surfaceTexture = toLowerANSI (surfaceTexture _pos);
 [_surface, 2, _fnc_scriptName] call HATG_fnc_log;
 [_surfaceTexture, 2, _fnc_scriptName] call HATG_fnc_log;
 
-if (["hatg_setting_surfaces", false] call HATG_fnc_getVariable isEqualTo false) exitWith {true}; // If the setting to ignore surfaces is off, return true
+if !(hatg_setting_surfaces) exitWith {true}; // If the setting to ignore surfaces is off, return true
 if ("grass" in _surface || {"grass" in _surfaceTexture}) exitWith {true};
 
 false;

--- a/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
@@ -30,6 +30,7 @@ private _surfaceTexture = toLowerANSI (surfaceTexture _pos);
 [_surfaceTexture, 2, _fnc_scriptName] call HATG_fnc_log;
 
 if !(hatg_setting_surfaces) exitWith {true}; // If the setting to ignore surfaces is off, return true
+if ([_unit] call HATG_fnc_isInBuilding) exitWith {true};
 if ("grass" in _surface || {"grass" in _surfaceTexture}) exitWith {true};
 
 false;

--- a/hatg/addons/functions/functions/debug/fn_batchTesting.sqf
+++ b/hatg/addons/functions/functions/debug/fn_batchTesting.sqf
@@ -1,0 +1,33 @@
+params [["_unit", player]];
+
+// RUN ON STRATIS ONLY, OTHERWISE RESULTS WILL NOT BE ACCURATE
+
+private _testPositions = [
+	[1985.75,3563.35,0], // grass
+	[1922.38,3511.17,0], // sand
+	[1950.26,3527.46,0], // dirt
+	[1979.89,4129.44,0], // sand (bush)
+	[1945.8,3581.37,0], // road
+	[1972.86,3505.64,3], // cargo hq (roof)
+	[1972.86,3505.64,1] // cargo hq (interior)
+];
+
+private _testStances = [
+	"PlayerProne",
+	"PlayerCrouch",
+	"PlayerStand"
+];
+
+hatg_setting_debug = true;
+
+{
+	private _stance = _x;
+	player playActionNow _stance;
+	{
+		private _pos = _x;
+		player setPosATL _pos;
+		
+		uiSleep 3;
+	} forEach _testPositions;
+	uiSleep 1;
+} forEach _testStances;

--- a/hatg/addons/functions/functions/debug/fn_isDebug.sqf
+++ b/hatg/addons/functions/functions/debug/fn_isDebug.sqf
@@ -3,14 +3,14 @@
         Silence
     
     Description:
-        Returns the CBA setting missionNamespace "hatg_setting_debug"
+        Returns the global "hatg_setting_debug"
     
     Params:
         N/A
     
     Dependencies:
-        missionNamespace variables:
-        > "hatg_setting_debug" <BOOL>
+        global variables:
+        > hatg_setting_debug <BOOL>
     
     Usage:
         call HATG_fnc_isDebug;
@@ -19,6 +19,6 @@
         _isDebug <BOOL>
 */
 
-private _isDebug = ["hatg_setting_debug", false] call HATG_fnc_getVariable;
+private _isDebug = hatg_setting_debug;
 
 _isDebug;

--- a/hatg/addons/functions/functions/debug/fn_log.sqf
+++ b/hatg/addons/functions/functions/debug/fn_log.sqf
@@ -3,15 +3,16 @@
         Silence
     
     Description:
-        Handles logging messages with different debug levels.
+        Handles logging messages with different debug levels (+ Server logging).
     
     Params:
         _message <STRING> <Default: "">
         _level <INT> <Default: 0>
         _script <STRING> <Default: _fnc_scriptName>
+        _server <BOOL> <Default: false>
     
     Dependencies:
-        missionNamespace variables:
+        global variables:
         > "hatg_setting_debug_surface" <BOOL>
         > "hatg_setting_debug_conditions" <BOOL>
         > "hatg_setting_debug_detection" <BOOL>
@@ -33,9 +34,9 @@ params [
 private _logMessage = format ["| Hide Among The Grass | %1 | %2 |", _message, _script];
 
 if (_level == 1 && {call HATG_fnc_isDebug isEqualTo false}) exitWith {nil};
-if (_level == 2 && {["hatg_setting_debug_surface", false] call HATG_fnc_getVariable isEqualTo false}) exitWith {nil};
-if (_level == 3 && {["hatg_setting_debug_conditions", false] call HATG_fnc_getVariable isEqualTo false}) exitWith {nil};
-if (_level == 4 && {["hatg_setting_debug_detection", false] call HATG_fnc_getVariable isEqualTo false}) exitWith {nil};
+if (_level == 2 && {hatg_setting_debug_surface isEqualTo false}) exitWith {nil};
+if (_level == 3 && {hatg_setting_debug_conditions isEqualTo false}) exitWith {nil};
+if (_level == 4 && {hatg_setting_debug_detection isEqualTo false}) exitWith {nil};
 
 if (_server) exitWith {[_message, _level, _script, false] remoteExec ["HATG_fnc_log", 2]};
 

--- a/hatg/addons/functions/functions/equipment/fn_getGhillies.sqf
+++ b/hatg/addons/functions/functions/equipment/fn_getGhillies.sqf
@@ -1,5 +1,5 @@
-private _ghilliesWhitelist = ["hatg_setting_equipment_ghillie_whitelist", []] call HATG_fnc_getVariable;
-private _ghilliesBlacklist = ["hatg_setting_equipment_ghillie_blacklist", []] call HATG_fnc_getVariable;
+private _ghilliesWhitelist = hatg_setting_equipment_ghillie_whitelist;
+private _ghilliesBlacklist = hatg_setting_equipment_ghillie_blacklist;
 
 try {
     _ghilliesWhitelist = parseSimpleArray _ghilliesWhitelist;

--- a/hatg/addons/functions/functions/equipment/fn_getSuppressors.sqf
+++ b/hatg/addons/functions/functions/equipment/fn_getSuppressors.sqf
@@ -1,6 +1,6 @@
-private _suppressorsWhitelist = ["hatg_setting_equipment_suppressor_whitelist", []] call HATG_fnc_getVariable;
-private _suppressorsBlacklist = ["hatg_setting_equipment_suppressor_blacklist", []] call HATG_fnc_getVariable;
-private _suppressorsIntegral = ["hatg_setting_equipment_suppressor_integral", []] call HATG_fnc_getVariable;
+private _suppressorsWhitelist = hatg_setting_equipment_suppressor_whitelist;
+private _suppressorsBlacklist = hatg_setting_equipment_suppressor_blacklist;
+private _suppressorsIntegral = hatg_setting_equipment_suppressor_integral;
 
 try {
     _suppressorsWhitelist = parseSimpleArray _suppressorsWhitelist;

--- a/hatg/addons/functions/functions/handlers/fn_onFired.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onFired.sqf
@@ -9,7 +9,7 @@
         _unit <OBJECT>
     
     Dependencies:
-        missionNamespace variables:
+        global variables:
         > "hatg_setting_cooldown" <INT>
         > "hatg_setting_distance_reset" <INT>
         > "hatg_setting_distance_shots" <INT>
@@ -26,8 +26,8 @@
 
 params ["_unit"];
     
-private _cooldown = ["hatg_setting_cooldown", -1] call HATG_fnc_getVariable;
-private _resetDistance = ["hatg_setting_distance_reset", -1] call HATG_fnc_getVariable;
+private _cooldown = hatg_setting_cooldown;
+private _resetDistance = hatg_setting_distance_reset;
 
 // Get the unit "information", shots and position
 private _unitInformation = ["hatg_mirror_unitInformation", [], _unit] call HATG_fnc_getVariable;

--- a/hatg/addons/functions/functions/mirror/fn_canCreateMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_canCreateMirror.sqf
@@ -28,25 +28,25 @@ if (_unit isEqualTo ObjNull) exitWith {false};
 
 private _mirror = [_unit] call HATG_fnc_getMirror;
 
+private _unitInVehicle = !(isNull objectParent _unit);
+if (_unitInVehicle) exitWith {["In Vehicle Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
+
 private _cooldown = _unit getVariable ["hatg_mirror_cooldown", false];
 if (_cooldown) exitWith {["Cooldown Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
+
+private _movementSpeed = speed _unit;
+if (_stance isEqualTo "CROUCH" && {_movementSpeed > hatg_setting_movement_crouch}) exitWith {["Movement Speed Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
 
 private _surfaceIsGrass = [_unit] call HATG_fnc_surfaceIsGrass;
 if !(_surfaceIsGrass) exitWith {["Surface Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
 
-private _unitInVehicle = !(isNull objectParent _unit);
-if (_unitInVehicle) exitWith {["In Vehicle Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
+private _isOnFloor = [_unit] call HATG_fnc_isOnFloor;
+if !(_isOnFloor) exitWith {["On Floor Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
 
 private _isOnRoad = isOnRoad _unit;
 if (_isOnRoad) exitWith {["On Road Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
 
-private _isOnFloor = [_unit] call HATG_fnc_isOnFloor;
-if !(_isOnFloor) exitWith {["On Floor Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
-
 private _unitsClose = [_unit, _stance] call HATG_fnc_getNearbyUnits;
 if (_unitsClose) exitWith {["Close Units Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
-
-private _movementSpeed = speed _unit;
-if (_stance isEqualTo "CROUCH" && {_movementSpeed > hatg_setting_movement_crouch}) exitWith {["Movement Speed Check Failed", 3, _fnc_scriptName] call HATG_fnc_log; false};
 
 true

--- a/hatg/addons/functions/functions/mirror/fn_cooldown.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_cooldown.sqf
@@ -13,7 +13,7 @@
         _unit Namespace variables:
         > "hatg_mirror_cooldown"
 
-        missionNamespace variables:
+        global variables:
         > "hatg_setting_cooldown"
     
     Usage:
@@ -35,7 +35,7 @@ _unit setVariable ["hatg_mirror_cooldown", true];
 ["Set cooldown to true", 1, _fnc_scriptName] call HATG_fnc_log;
 
 if (_cooldown isEqualTo -1) then {
-    _cooldown = ["hatg_setting_cooldown", -1] call HATG_fnc_getVariable;
+    _cooldown = hatg_setting_cooldown;
 };
 
 [

--- a/hatg/addons/gui/functions/display/fn_createDisplay.sqf
+++ b/hatg/addons/gui/functions/display/fn_createDisplay.sqf
@@ -9,7 +9,7 @@ disableSerialization;
 
 #define IDC_HIDDENTEXT 10000
 
-private _id = ["layer" + _displayName] call BIS_fnc_rscLayer;
+private _id = ["HATG_layer" + _displayName] call BIS_fnc_rscLayer;
 _id cutRsc [_displayName, "PLAIN", 0, false, true];
 private _display = uiNamespace getVariable _displayName;
 

--- a/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
+++ b/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
@@ -11,7 +11,7 @@ private _textSize = hatg_setting_ui_textsize;
 private _displayColourHidden = hatg_setting_ui_colour_hidden;
 private _displayColourRevealed = hatg_setting_ui_colour_revealed;
 
-if !(["hatg_setting_ui", false] call HATG_fnc_getVariable) exitWith {
+if !(hatg_setting_ui) exitWith {
     if (ctrlText _displayHidden isEqualTo "") exitWith {};
     
     private _hiddenText = "";


### PR DESCRIPTION
# What purpose does this PR serve?
1. [x] Bug
2. [x] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:

Converted most vars to global rather than missionNamespace, removes overhead of grabbing vars

### Why was this change necessary?
Details:

## Does this PR resolve any open issues?
1. [ ] No
2. [ ] Yes

***If applicable, fill out below.***

This PR closes #ISSUENUMBER

## Is any extra work required or advised?

1. [ ] No
2. [ ] Yes (Explain below)

Details: