### PR TITLE
Potentially fix mirror not deleting upon disconnect

### DIFF
--- a/hatg/addons/functions/CfgFunctions.hpp
+++ b/hatg/addons/functions/CfgFunctions.hpp
@@ -42,6 +42,7 @@ class CfgFunctions
             file = QPATHTOFOLDER(functions\handlers);
             class addHandlers {};
             class handleDamage {};
+            class handleDisconnect {};
             class handleFired {};
             class handleFiredNear {};
             class handleGroupCreated {};

--- a/hatg/addons/functions/functions/cba/fn_settings.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings.sqf
@@ -21,26 +21,30 @@
 
         // This is mostly intended for singleplayer
         hatg_setting_simple = _value;
-        hatg_setting_surfaces = false;
-        hatg_setting_reveal_nearby = false;
-        hatg_setting_cooldown = 5;
-        hatg_setting_distance_close = 10;
-        hatg_setting_distance_height = 2;
-        hatg_setting_distance_close_multiplier = 0;
-        hatg_setting_distance_reset = -1;
-        hatg_setting_distance_shots = -1;
-        hatg_setting_movement_crouch = 20;
-        publicVariable "hatg_setting_simple";
-        publicVariable "hatg_setting_surfaces";
-        publicVariable "hatg_setting_reveal_nearby";
-        publicVariable "hatg_setting_cooldown";
-        publicVariable "hatg_setting_distance_close";
-        publicVariable "hatg_setting_distance_height";
-        publicVariable "hatg_setting_distance_close_multiplier";
-        publicVariable "hatg_setting_distance_reset";
-        publicVariable "hatg_setting_distance_shots";
-        publicVariable "hatg_setting_movement_crouch";
-    }
+
+        if (_value isEqualTo true) then {
+            hatg_setting_surfaces = false;
+            hatg_setting_reveal_nearby = false;
+            hatg_setting_cooldown = 5;
+            hatg_setting_distance_close = 10;
+            hatg_setting_distance_height = 2;
+            hatg_setting_distance_close_multiplier = 0;
+            hatg_setting_distance_reset = -1;
+            hatg_setting_distance_shots = -1;
+            hatg_setting_movement_crouch = 20;
+            publicVariable "hatg_setting_simple";
+            publicVariable "hatg_setting_surfaces";
+            publicVariable "hatg_setting_reveal_nearby";
+            publicVariable "hatg_setting_cooldown";
+            publicVariable "hatg_setting_distance_close";
+            publicVariable "hatg_setting_distance_height";
+            publicVariable "hatg_setting_distance_close_multiplier";
+            publicVariable "hatg_setting_distance_reset";
+            publicVariable "hatg_setting_distance_shots";
+            publicVariable "hatg_setting_movement_crouch";
+        };
+    },
+    true
 ] call CBA_fnc_addSetting;
 
 [

--- a/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
@@ -1,0 +1,31 @@
+/*
+    Author:
+        Silence
+    
+    Description:
+        Adds a "HandleDisconnect" mission event handler.
+    
+    Params:
+        N/A
+    
+    Dependencies:
+        N/A
+    
+    Usage:
+        call HATG_fnc_handleDisconnect;
+    
+    Return:
+        _ehHandleDisconnect <INT>
+*/
+
+private _ehHandleDisconnect = addMissionEventHandler ["HandleDisconnect", {
+	params ["_unit", "_id", "_uid", "_name"];
+    
+    if !(isMultiplayer) exitWith {};
+
+    [_unit] call HATG_fnc_deleteMirror;
+
+    false;
+}];
+
+_ehGroupCreated;

--- a/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
@@ -23,7 +23,11 @@ private _ehHandleDisconnect = addMissionEventHandler ["HandleDisconnect", {
     
     if !(isMultiplayer) exitWith {};
 
-    [_unit] call HATG_fnc_deleteMirror;
+    private _mirror = [_unit] call HATG_fnc_getMirror;
+
+    if (_mirror isNotEqualTo ObjNull) then {
+        deleteVehicle _mirror;
+    };
 
     false;
 }];

--- a/hatg/addons/functions/functions/handlers/fn_handleStance.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_handleStance.sqf
@@ -22,7 +22,7 @@ params ["_unit"];
 
 // I couldn't find an event handler specifically for stances and I didn't want to use an event handler for general anim changes, so this is what it is
 
-while {alive _unit} do
+while {alive _unit || {!(isNil "_unit")}} do
 {
     private _exit = [_unit] call HATG_fnc_onStance;
 

--- a/hatg/addons/functions/functions/handlers/fn_onFired.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onFired.sqf
@@ -60,10 +60,10 @@ if (_canStayHidden) exitWith {}; // If they should remain hidden then don't do a
 
 private _isHidden = [_unit] call HATG_fnc_getMirror isNotEqualTo ObjNull;
 if !(_isHidden) exitWith {
-    [format ["%1 fired whilst not hidden.", name _unit, (round(_cooldown / 10))], 1, _fnc_scriptName] call HATG_fnc_log;
+    [format ["%1 fired whilst not hidden.", name _unit], 1, _fnc_scriptName] call HATG_fnc_log;
     [_unit, (round(_cooldown / 10))] call HATG_fnc_cooldown; // if they shoot whilst not prone, give them 3 seconds to wait instead of 30. (default, 30. Divided by 10 = 3)
 };
 
-[format ["%1 fired whilst hidden.", name _unit, _cooldown], 1, _fnc_scriptName] call HATG_fnc_log;
+[format ["%1 fired whilst hidden.", name _unit], 1, _fnc_scriptName] call HATG_fnc_log;
 [_unit] call HATG_fnc_deleteMirror;
 [_unit, _cooldown] call HATG_fnc_cooldown;

--- a/hatg/addons/functions/functions/handlers/fn_onFiredNear.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onFiredNear.sqf
@@ -21,7 +21,7 @@
 
 params ["_unit", "_firer"];
 
-[format["%1 was caught in a 'fired' event. %2 was the firer. Checking conditions"], 4, _fnc_scriptName] call HATG_fnc_log;
+[format["%1 was caught in a 'fired' event. %2 was the firer. Checking conditions", name _unit, name _firer], 4, _fnc_scriptName] call HATG_fnc_log;
 
 if (hatg_setting_reveal_nearby isEqualTo false) exitWith {["Failed 'Fired' Setting Check", 4, _fnc_scriptName] call HATG_fnc_log; false};
 if ([_firer] call HATG_fnc_getMirror isNotEqualTo ObjNull) exitWith {["Failed 'Fired' Mirror Check", 4, _fnc_scriptName] call HATG_fnc_log; false};

--- a/hatg/addons/functions/functions/init/fn_preInit.sqf
+++ b/hatg/addons/functions/functions/init/fn_preInit.sqf
@@ -1,4 +1,8 @@
-if (isServer) then {missionNamespace setVariable ["hatg_serverActivated", true, true]};
+if (isServer) then {
+    missionNamespace setVariable ["hatg_serverActivated", true, true];
+
+    // call HATG_fnc_handleDisconnect; // may not be necessary, tbh not sure if it even works due to networking
+};
 
 call HATG_fnc_settings;
 

--- a/hatg/addons/functions/functions/init/fn_preInit.sqf
+++ b/hatg/addons/functions/functions/init/fn_preInit.sqf
@@ -1,7 +1,7 @@
 if (isServer) then {
     missionNamespace setVariable ["hatg_serverActivated", true, true];
 
-    // call HATG_fnc_handleDisconnect; // may not be necessary, tbh not sure if it even works due to networking
+    call HATG_fnc_handleDisconnect;
 };
 
 call HATG_fnc_settings;

--- a/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
@@ -38,7 +38,7 @@ private _mirror = _mirrorType createVehicle [0,0,0];
 _mirror setPosATL getPosATL _unit;
 _mirror attachTo [_unit, [0,0,0]];
 
-["hatg_mirror", _mirror, _unit] call HATG_fnc_setVariable;
+_unit setVariable ["hatg_mirror", _mirror, true];
 
 if (isPlayer _unit) then {
     [_unit] call HATG_fnc_handleDisplayText;

--- a/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
@@ -34,7 +34,7 @@ if (_mirror isEqualTo ObjNull) exitWith {false}; // if mirror is still ObjNull t
 [format["Deleting a mirror at position (ATL: %1)", getPosATL _mirror], 1, _fnc_scriptName] call HATG_fnc_log;
 
 deleteVehicle _mirror;
-_unit setVariable ["hatg_mirror", ObjNull];
+_unit setVariable ["hatg_mirror", ObjNull, true];
 
 if (isPlayer _unit) then {
     [_unit] call HATG_fnc_handleDisplayText;


### PR DESCRIPTION
# What purpose does this PR serve?
1. [x] Bug
2. [ ] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:

Added an isNil check to the handleStance loop;
Added a HandleDisconnect missionEventHandler

### Why was this change necessary?
Details:

It should now delete the mirror of a player when they disconnect

### Does this pull request change core HATG functionality?
1. [x] No
2. [ ] Yes

**If yes, what core functionality does it change and why?**

**[HATG Automated Testing Result](https://github.com/SilenceIsFatto/HATG/blob/main/hatg/addons/functions/functions/debug/fn_batchTesting.sqf):**

```
Paste Below

23:17:21 "| Hide Among The Grass | Setting - Detection - Surfaces: true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Setting - Detection - Buildings: true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Setting - Detection - Reveal Nearby: true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Setting - Detection - Distance Close: 20 | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Setting - Detection - Distance Close Multiplier: 2 | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Setting - Detection - Distance Height: 2 | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Starting Batch Testing With Stance: PlayerProne | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Grass. Result: true. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Sand. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Dirt. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Sand (With Bush). Result: true. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Road. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Cargo HQ (Exterior). Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerProne). Area: Cargo HQ (Interior). Result: true. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Starting Batch Testing With Stance: PlayerCrouch | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Grass. Result: true. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Sand. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Dirt. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Sand (With Bush). Result: true. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Road. Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Cargo HQ (Exterior). Result: false. Passed? true | hatg_fnc_log |"
23:17:21 "| Hide Among The Grass | Batch Testing (PlayerCrouch). Area: Cargo HQ (Interior). Result: true. Passed? true | hatg_fnc_log |"
```

## Does this PR resolve any open issues?
1. [ ] No
2. [x] Yes

***If applicable, fill out below.***

This PR closes #8

## Is any extra work required or advised?

1. [ ] No
2. [x] Yes (Explain below)

Details:

Need to make sure that this does not cause any issues when players disconnect