### PR TITLE
Add setting for stealth AI in MP

### DIFF
--- a/hatg/addons/functions/functions/cba/fn_settings.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings.sqf
@@ -27,6 +27,24 @@
 ] call CBA_fnc_addSetting;
 
 [
+    "hatg_setting_mp_ai", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "CHECKBOX", // setting type
+    ["$STR_HATG_MP_AI", "$STR_HATG_MP_AI_info"], // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    SETTING_HEADER_GENERAL, // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    false,
+    true, // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+    {
+        params ["_value"];
+
+        // This is mostly intended for singleplayer, the mirror will always be active unless you do something to reveal it
+        hatg_setting_mp_ai = _value;
+
+        publicVariable "hatg_setting_mp_ai";
+    },
+    true
+] call CBA_fnc_addSetting;
+
+[
     "hatg_setting_debug",
     "CHECKBOX",
     "$STR_HATG_Debug",

--- a/hatg/addons/functions/functions/handlers/fn_addHandlers.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_addHandlers.sqf
@@ -40,7 +40,7 @@ if (_respawn isEqualTo false) then {
 ["hatg_handlers_activated", true, _unit] call HATG_fnc_setVariable;
 
 // Word of advice: Don't run addHandlers when these ifs return true the second time around... you may cause a recursion loop and freeze the game...
-if (!isMultiplayer && {isPlayer _unit}) then {
+if ((hatg_setting_mp_ai || {!isMultiplayer}) && {isPlayer _unit}) then {
     private _unitGroup = group _unit;
 
     {

--- a/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_handleDisconnect.sqf
@@ -21,7 +21,7 @@
 private _ehHandleDisconnect = addMissionEventHandler ["HandleDisconnect", {
 	params ["_unit", "_id", "_uid", "_name"];
     
-    if !(isMultiplayer) exitWith {};
+    if (!isMultiplayer) exitWith {};
 
     private _mirror = [_unit] call HATG_fnc_getMirror;
 

--- a/hatg/addons/functions/functions/handlers/fn_handleGroupCreated.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_handleGroupCreated.sqf
@@ -23,7 +23,7 @@ private _ehGroupCreated = addMissionEventHandler ["GroupCreated", {
 
     private _leader = leader _group;
 
-    if (!(isMultiplayer) && {isPlayer _leader}) then {
+    if ((hatg_setting_mp_ai || {!isMultiplayer}) && {isPlayer _leader}) then {
         [_group] call HATG_fnc_handleUnitJoined;
     };
 }];

--- a/hatg/addons/functions/functions/init/fn_postInit.sqf
+++ b/hatg/addons/functions/functions/init/fn_postInit.sqf
@@ -8,6 +8,6 @@ if (isClass (configFile >> "CfgPatches" >> "HIG_wall")) exitWith {titleText ["HA
 
 call HATG_fnc_createDisplay;
 
-if !(isMultiplayer) then {
+if (hatg_setting_mp_ai || {!isMultiplayer}) then {
     call HATG_fnc_handleGroupCreated;
 };

--- a/hatg/addons/gui/stringtable.xml
+++ b/hatg/addons/gui/stringtable.xml
@@ -36,6 +36,40 @@
 				<Portuguese>Esta configuração sobrescreve todas as outras. É destinada a uma experiência mais 'arcade'. Não altere outras configurações com esta opção ativada, pois elas serão sobrescritas no próximo reinício do jogo.</Portuguese>
 				<Turkish>Bu ayar diğer tüm ayarların üzerine yazar. Daha 'atari' tarzı bir deneyim için tasarlanmıştır. Bu ayar etkinleştirildiğinde diğer ayarları değiştirmeyin; bunlar, oyunun bir sonraki yeniden başlatılmasında üzerine yazılacaktır.</Turkish>
 			</Key>
+			<Key ID="STR_HATG_MP_AI">
+				<Original>Enable AI Support In MP</Original>
+				<English>Enable AI Support In MP</English>
+				<Czech>Povolit podporu AI v MP</Czech>
+				<French>Activer le support de l'IA en MP</French>
+				<German>KI-Unterstützung in MP aktivieren</German>
+				<Italian>Abilita supporto IA in MP</Italian>
+				<Polish>Włącz wsparcie AI w MP</Polish>
+				<Russian>Включить поддержку ИИ в МП</Russian>
+				<Spanish>Habilitar soporte de IA en MP</Spanish>
+				<Korean>MP에서 AI 지원 활성화</Korean>
+				<Japanese>MPでAIサポートを有効にする</Japanese>
+				<Chinesesimp>启用MP中的AI支持</Chinesesimp>
+				<Chinese>啟用MP中的AI支持</Chinese>
+				<Portuguese>Ativar suporte de IA no MP</Portuguese>
+				<Turkish>MP'de AI desteğini etkinleştir</Turkish>
+			</Key>
+			<Key ID="STR_HATG_MP_AI_info">
+				<Original>This setting allows AI in player groups to become 'hidden' in multiplayer.</Original>
+				<English>This setting allows AI in player groups to become 'hidden' in multiplayer.</English>
+				<Czech>Toto nastavení umožňuje AI ve skupinách hráčů stát se „skrytými“ v multiplayeru.</Czech>
+				<French>Ce paramètre permet à l'IA dans les groupes de joueurs de devenir « cachée » en multijoueur.</French>
+				<German>Diese Einstellung ermöglicht es der KI in Spielergruppen, im Mehrspielermodus „versteckt“ zu werden.</German>
+				<Italian>Questa impostazione consente all'IA nei gruppi di giocatori di diventare "nascosta" nel multiplayer.</Italian>
+				<Polish>To ustawienie pozwala, aby AI w grupach graczy stało się „ukryte” w trybie multiplayer.</Polish>
+				<Russian>Этот параметр позволяет ИИ в группах игроков стать «скрытым» в многопользовательском режиме.</Russian>
+				<Spanish>Esta configuración permite que la IA en grupos de jugadores se vuelva "oculta" en el multijugador.</Spanish>
+				<Korean>이 설정은 MP에서 플레이어 그룹의 AI가 '숨김' 상태가 되도록 허용합니다.</Korean>
+				<Japanese>この設定により、プレイヤーグループ内のAIがマルチプレイヤーで「隠れる」ようになります。</Japanese>
+				<Chinesesimp>此设置允许玩家组中的AI在多人游戏中变为“隐藏”。</Chinesesimp>
+				<Chinese>此設置允許玩家組中的AI在多人遊戲中變為「隱藏」。</Chinese>
+				<Portuguese>Essa configuração permite que a IA em grupos de jogadores fique "oculta" no multijogador.</Portuguese>
+				<Turkish>Bu ayar, oyuncu gruplarındaki yapay zekanın çok oyunculu modda "gizli" hale gelmesine izin verir.</Turkish>
+			</Key>
 			<Key ID="STR_HATG_Debug">
 				<Original>Debug Mode</Original>
 				<English>Debug Mode</English>


### PR DESCRIPTION
# What purpose does this PR serve?
1. [ ] Bug
2. [x] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:

Added a setting to allow AI to be stealthy in MP

### Why was this change necessary?
Details:

So servers can choose to allow stealthy AI, or for local SP servers such as Antistasi

### Does this pull request change core HATG functionality?
1. [x] No
2. [ ] Yes

**If yes, what core functionality does it change and why?**

**[HATG Automated Testing Result](https://github.com/SilenceIsFatto/HATG/blob/main/hatg/addons/functions/functions/debug/fn_batchTesting.sqf):**

```
Paste Below
```

## Does this PR resolve any open issues?
1. [x] No
2. [ ] Yes

***If applicable, fill out below.***

This PR closes #ISSUENUMBER

## Is any extra work required or advised?

1. [ ] No
2. [x] Yes (Explain below)

Details:

Make sure it doesn't crash the game when 2 players join a squad that already has handlers on it