### PR TITLE
Make UI visible on postInit

### DIFF
--- a/hatg/addons/functions/functions/cba/fn_settings_ui.sqf
+++ b/hatg/addons/functions/functions/cba/fn_settings_ui.sqf
@@ -8,7 +8,10 @@
     ["$STR_HATG_UI_Enable", "$STR_HATG_UI_Enable_info"],
     SETTING_HEADER_UI, 
     false,
-    0
+    0,
+    {
+        [player] call HATG_fnc_handleDisplayText;
+    }
 ] call CBA_fnc_addSetting;
 
 [

--- a/hatg/addons/functions/functions/init/fn_postInit.sqf
+++ b/hatg/addons/functions/functions/init/fn_postInit.sqf
@@ -4,9 +4,12 @@ private _serverActivated = ["hatg_serverActivated", false] call HATG_fnc_getVari
 if !(_serverActivated) exitWith {titleText ["HATG is not a client mod and needs to be ran on the server too. HATG features will not work until the server loads the mod.", "PLAIN"]};
 if (isClass (configFile >> "CfgPatches" >> "HIG_wall")) exitWith {titleText ["HATG should not be running alongside ACSTG, please disable it. HATG will now be disabled to prevent conflicts.", "PLAIN"]};
 
+// Should probably localize the above error messages
+
 [player] call HATG_fnc_addHandlers;
 
 call HATG_fnc_createDisplay;
+[player] call HATG_fnc_handleDisplayText;
 
 if !(isMultiplayer) then {
     call HATG_fnc_handleGroupCreated;

--- a/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
+++ b/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
@@ -16,10 +16,9 @@ private _displayImage = QPATHTOFOLDER(data\ui\revealed_ca.paa);
 private _colour = _displayColourRevealed;
 
 if !(hatg_setting_ui) exitWith {
-    if (ctrlText _displayHidden isEqualTo "") exitWith {};
-    
     private _hiddenText = "";
     _displayHidden ctrlSetStructuredText (parseText _hiddenText);
+    _displayHidden ctrlCommit 0;
 };
 
 if (["hatg_mirror", ObjNull, _unit] call HATG_fnc_getVariable isNotEqualTo ObjNull) then {


### PR DESCRIPTION
# What purpose does this PR serve?
1. [ ] Bug
2. [x] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:

The UI will now show up on mission start rather than the first time you are hidden (with the setting enabled)

### Why was this change necessary?
Details:

People were confused as to why the UI was "not working"

### Does this pull request change core HATG functionality?
1. [x] No
2. [ ] Yes

**If yes, what core functionality does it change and why?**

**[HATG Automated Testing Result](https://github.com/SilenceIsFatto/HATG/blob/main/hatg/addons/functions/functions/debug/fn_batchTesting.sqf):**

```
Paste Below
```

## Does this PR resolve any open issues?
1. [x] No
2. [ ] Yes

***If applicable, fill out below.***

This PR closes #ISSUENUMBER

## Is any extra work required or advised?

1. [x] No
2. [ ] Yes (Explain below)

Details: