### PR TITLE
Transition keybinds to CfgUserActions.hpp

### DIFF
--- a/hatg/addons/core/cfgUserActions.hpp
+++ b/hatg/addons/core/cfgUserActions.hpp
@@ -1,0 +1,35 @@
+class CfgUserActions
+{
+	class MOD(action_refresh)
+	{// This class name is used for internal representation and also for the inputAction command.
+		displayName = "$STR_HATG_Keybind_Refresh";
+		tooltip = "$STR_HATG_Keybind_Refresh_Info";
+		onActivate = "call HATG_fnc_refreshUI";		// _this is always true.
+		onDeactivate = "";		// _this is always false.
+		onAnalog = "";	// _this is the scalar analog value.
+		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
+	};
+	class MOD(action_toggle)
+	{// This class name is used for internal representation and also for the inputAction command.
+		displayName = "$STR_HATG_Keybind_Toggle";
+		tooltip = "$STR_HATG_Keybind_Toggle_Info";
+		onActivate = "call HATG_fnc_toggleUI";		// _this is always true.
+		onDeactivate = "";		// _this is always false.
+		onAnalog = "";	// _this is the scalar analog value.
+		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
+	};
+};
+
+class UserActionGroups
+{
+	class MOD(actions)
+	{
+		name = "Hide Among The Grass"; // Display name of your category.
+		isAddon = 1;
+		group[] =
+		{
+			MOD(action_refresh),
+			MOD(action_toggle)
+		};
+	};
+};

--- a/hatg/addons/core/config.cpp
+++ b/hatg/addons/core/config.cpp
@@ -24,3 +24,5 @@ class CfgVehicles
 {
 	#include "CfgVehicles.hpp"
 };
+
+#include "CfgUserActions.hpp"

--- a/hatg/addons/functions/CfgFunctions.hpp
+++ b/hatg/addons/functions/CfgFunctions.hpp
@@ -61,7 +61,9 @@ class CfgFunctions
             class getVariable {};
             class postInit {};
             class preInit {};
+            class refreshUI {};
             class setVariable {};
+            class toggleUI {};
         };
         class mirror 
         {

--- a/hatg/addons/functions/functions/cba/fn_keybinds.sqf
+++ b/hatg/addons/functions/functions/cba/fn_keybinds.sqf
@@ -4,6 +4,8 @@
 #define KEYBIND_HEADER Hide Among The Grass
 #define KEYBIND_HEADER_QUOTE QUOTE(KEYBIND_HEADER)
 
+// Not used anymore
+
 [KEYBIND_HEADER_QUOTE, "hatg_keybind_refresh", ["$STR_HATG_Keybind_Refresh", "$STR_HATG_Keybind_Refresh_Info"], {
     [] call HATG_fnc_createDisplay;
 
@@ -12,7 +14,7 @@
     [_width, _height] call HATG_fnc_handleDisplayPosition;
 
     [player] call HATG_fnc_handleDisplayText;
-}, {}, [DIK_COMMA, [false, false, false]]] call CBA_fnc_addKeybind;
+}, {}, [-1, [false, false, false]]] call CBA_fnc_addKeybind;
 
 [KEYBIND_HEADER_QUOTE, "hatg_keybind_toggle", ["$STR_HATG_Keybind_Toggle", "$STR_HATG_Keybind_Toggle_Info"], {
     private _enabled = ["hatg_mirror_toggle", false, player] call HATG_fnc_getVariable;
@@ -20,4 +22,4 @@
     ["hatg_mirror_toggle", (!_enabled), player] call HATG_fnc_setVariable;
 
     [player] call HATG_fnc_handleDisplayText;
-}, {}, [DIK_SLASH, [false, false, false]]] call CBA_fnc_addKeybind;
+}, {}, [-1, [false, false, false]]] call CBA_fnc_addKeybind;

--- a/hatg/addons/functions/functions/init/fn_postInit.sqf
+++ b/hatg/addons/functions/functions/init/fn_postInit.sqf
@@ -6,7 +6,8 @@ if (isClass (configFile >> "CfgPatches" >> "HIG_wall")) exitWith {titleText ["HA
 
 // Should probably localize the above error messages
 
-call HATG_fnc_keybinds;
+// Commented out in favour of CfgUserActions
+// call HATG_fnc_keybinds;
 
 [player] call HATG_fnc_addHandlers;
 

--- a/hatg/addons/functions/functions/init/fn_refreshUI.sqf
+++ b/hatg/addons/functions/functions/init/fn_refreshUI.sqf
@@ -1,0 +1,7 @@
+[] call HATG_fnc_createDisplay;
+
+private _width = ["hatg_setting_ui_x", 0.45] call HATG_fnc_getVariable;
+private _height = ["hatg_setting_ui_y", 1.7] call HATG_fnc_getVariable;
+[_width, _height] call HATG_fnc_handleDisplayPosition;
+
+[player] call HATG_fnc_handleDisplayText;

--- a/hatg/addons/functions/functions/init/fn_toggleUI.sqf
+++ b/hatg/addons/functions/functions/init/fn_toggleUI.sqf
@@ -1,0 +1,5 @@
+private _enabled = ["hatg_mirror_toggle", false, player] call HATG_fnc_getVariable;
+
+["hatg_mirror_toggle", (!_enabled), player] call HATG_fnc_setVariable;
+
+[player] call HATG_fnc_handleDisplayText;


### PR DESCRIPTION
# What purpose does this PR serve?
1. [ ] Bug
2. [x] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:
Moved keybinds to CfgUserActions

### Why was this change necessary?
Details:
It's more flexible and allows to leave an empty keybind so it can be done manually

### Does this pull request change core HATG functionality?
1. [x] No
2. [ ] Yes

**If yes, what core functionality does it change and why?**

**[HATG Automated Testing Result](https://github.com/SilenceIsFatto/HATG/blob/main/hatg/addons/functions/functions/debug/fn_batchTesting.sqf):**

```
Paste Below
```

## Does this PR resolve any open issues?
1. [x] No
2. [ ] Yes

***If applicable, fill out below.***

This PR closes #ISSUENUMBER

## Is any extra work required or advised?

1. [x] No
2. [ ] Yes (Explain below)

Details: