### PR TITLE
Added additional grassy Altis surface texture

### DIFF
--- a/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
+++ b/hatg/addons/functions/functions/conditions/fn_surfaceIsGrass.sqf
@@ -29,7 +29,7 @@ private _surfaceTexture = toLowerANSI (surfaceTexture _pos);
 [_surface, 2, _fnc_scriptName] call HATG_fnc_log;
 [_surfaceTexture, 2, _fnc_scriptName] call HATG_fnc_log;
 
-private _surfacesNames = ["grass", "forest", "thorn", "field", "hlina", "trava"];
+private _surfacesNames = ["grass", "forest", "thorn", "field", "gdt_dirt_co", "hlina", "trava"];
 
 if !(hatg_setting_surfaces) exitWith {true};
 if (hatg_setting_simple) exitWith {true};


### PR DESCRIPTION
# What purpose does this PR serve?
1. [x] Bug
2. [ ] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
One surfaceTexture on Altis is not recognized as "grassy" despite being almost completely visually identical to other similar terrain, including similar groundclutter objects.

Surface texture ``gdt_dry_grass_co.paa`` is recognized as grassy, as expected:
https://i.imgur.com/DYszlaD.jpeg

Whereas surface texture ``gdt_dirt_co.paa`` isn't, despite being visually almost identical:
https://i.imgur.com/bjtoaaq.jpeg

### Why was this change necessary?
Lacking this specific surface makes the mod feel incredibly inconsistent, as there is no difference in the types of ground clutter between the two terrain features, and only a very subtle change in color to accompany it. You can be entirely hidden in grass in one patch of terrain, and be completely exposed in another patch less than five meters away with no discernible change in the amount or type of grass cover around you.

### Does this pull request change core HATG functionality?
1. [x] No
2. [ ] Yes

## Does this PR resolve any open issues?
1. [x] No
2. [ ] Yes

## Is any extra work required or advised?

1. [ ] No
2. [x] Yes (Explain below)

Something more than keyword searches for texture names may be advisable, since manually searching through every ``surfaceTexture`` on even the vanilla terrains for missing cases like this one would be a lot of treadmill work, not to mention modded terrains which are significantly more likely to have similar issues.

My personal suggestion might be to check ``surfaceType`` config data for its ``grassCover`` value instead, since that also governs how far units "sink into" terrain at a distance to represent foliage cover; maybe even cache results on map load into a hashmap so they can be easily checked again. Bohemia Interactive seems to use values as small as 0.03 for ground that would still be considered "grassy" by any ordinary person. For example, the ``GdtDirt`` surfaceType that corresponds to the second image seen above uses only 0.03 for its grassCover, and even ``GdtGrassDry`` uses only 0.05. This would also conveniently handle things like asphalt or concrete surfaces which BI has pretty universally set to 0 grassCover, and handle modded terrains that might have texture names written in other languages or simply not have a naming scheme which corresponds to the appropriate amount of foliage.

I'm well aware, however, this would be a much more comprehensive rewrite than the quick "hack fix" that I've got here, which only covers one specific ground texture which presents a pretty obvious problem on the vanilla maps. I can't claim to be a good enough developer to actually implement the suggestion above, I just know vaguely enough to propose a starting point.