### PR TITLE
Replace createVehicle/deleteVehicle with hideObject/hideObjectGlobal for mirror state transitions.

### DIFF
--- a/hatg/addons/functions/functions/handlers/fn_onStance.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onStance.sqf
@@ -31,19 +31,9 @@ if (hatg_setting_enable_crouch) then {
     _stances pushBack "CROUCH";
 };
 
-// if !(_stance in _stances) exitWith {[_unit] call HATG_fnc_deleteMirror; false};
-
-// if ([_unit, _stance] call HATG_fnc_canCreateMirror) exitWith {
-//     [_unit] call HATG_fnc_createMirror;
-//     false;
-// };
-
-// [_unit] call HATG_fnc_deleteMirror;
 
 
 if !(_stance in _stances) exitWith {
-    // 已经是隐藏状态就不重复调用
-    // If already hidden, do not call again
     if (_unit getVariable ["hatg_mirror_visible", false]) then {
         [_unit] call HATG_fnc_deleteMirror;
     };
@@ -51,16 +41,12 @@ if !(_stance in _stances) exitWith {
 };
 
 if ([_unit, _stance] call HATG_fnc_canCreateMirror) exitWith {
-    // 已经是显示状态就不重复调用
-    // If already visible, do not call again
     if !(_unit getVariable ["hatg_mirror_visible", false]) then {
         [_unit] call HATG_fnc_createMirror;
     };
     false;
 };
 
-// 已经是隐藏状态就不重复调用
-// If already hidden, do not call again
 if (_unit getVariable ["hatg_mirror_visible", false]) then {
     [_unit] call HATG_fnc_deleteMirror;
 };

--- a/hatg/addons/functions/functions/handlers/fn_onStance.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onStance.sqf
@@ -9,8 +9,9 @@
         _unit <OBJECT>
     
     Dependencies:
-        missionNamespace variables:
+        _unit variables:
         > "hatg_mirror_disable" <BOOL>
+        > "hatg_mirror_visible" <BOOL>
     
     Usage:
         [player] call HATG_fnc_onStance;
@@ -31,23 +32,23 @@ if (hatg_setting_enable_crouch) then {
     _stances pushBack "CROUCH";
 };
 
-
+private _mirrorVisible = _unit getVariable ["hatg_mirror_visible", false];
 
 if !(_stance in _stances) exitWith {
-    if (_unit getVariable ["hatg_mirror_visible", false]) then {
+    if (_mirrorVisible) then {
         [_unit] call HATG_fnc_deleteMirror;
     };
     false
 };
 
 if ([_unit, _stance] call HATG_fnc_canCreateMirror) exitWith {
-    if !(_unit getVariable ["hatg_mirror_visible", false]) then {
+    if !(_mirrorVisible) then {
         [_unit] call HATG_fnc_createMirror;
     };
     false;
 };
 
-if (_unit getVariable ["hatg_mirror_visible", false]) then {
+if (_mirrorVisible) then {
     [_unit] call HATG_fnc_deleteMirror;
 };
 

--- a/hatg/addons/functions/functions/handlers/fn_onStance.sqf
+++ b/hatg/addons/functions/functions/handlers/fn_onStance.sqf
@@ -31,13 +31,38 @@ if (hatg_setting_enable_crouch) then {
     _stances pushBack "CROUCH";
 };
 
-if !(_stance in _stances) exitWith {[_unit] call HATG_fnc_deleteMirror; false};
+// if !(_stance in _stances) exitWith {[_unit] call HATG_fnc_deleteMirror; false};
+
+// if ([_unit, _stance] call HATG_fnc_canCreateMirror) exitWith {
+//     [_unit] call HATG_fnc_createMirror;
+//     false;
+// };
+
+// [_unit] call HATG_fnc_deleteMirror;
+
+
+if !(_stance in _stances) exitWith {
+    // 已经是隐藏状态就不重复调用
+    // If already hidden, do not call again
+    if (_unit getVariable ["hatg_mirror_visible", false]) then {
+        [_unit] call HATG_fnc_deleteMirror;
+    };
+    false
+};
 
 if ([_unit, _stance] call HATG_fnc_canCreateMirror) exitWith {
-    [_unit] call HATG_fnc_createMirror;
+    // 已经是显示状态就不重复调用
+    // If already visible, do not call again
+    if !(_unit getVariable ["hatg_mirror_visible", false]) then {
+        [_unit] call HATG_fnc_createMirror;
+    };
     false;
 };
 
-[_unit] call HATG_fnc_deleteMirror;
+// 已经是隐藏状态就不重复调用
+// If already hidden, do not call again
+if (_unit getVariable ["hatg_mirror_visible", false]) then {
+    [_unit] call HATG_fnc_deleteMirror;
+};
 
 false;

--- a/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
@@ -36,18 +36,13 @@ if (_unit isEqualTo ObjNull) exitWith {false};
 private _mirror = [_unit] call HATG_fnc_getMirror;
 
 
-// mirror 已存在 → 直接显示并退出，不重复创建
-// hidden by default after creation, wait for conditions to be met before displaying
 if !(isNull _mirror) exitWith {
     _mirror hideObject false;
-    _mirror hideObjectGlobal false;
     _unit setVariable ["hatg_mirror_visible", true, true];
     if (isPlayer _unit) then { [_unit] call HATG_fnc_handleDisplayText; };
     _mirror
 };
 
-// mirror 不存在 → 创建
-// hidden by default after creation, wait for conditions to be met before displaying
 [format["Creating a mirror for %1 (ATL: %2)", name _unit, getPosATL _unit], 1, _fnc_scriptName] call HATG_fnc_log;
 
 private _mirrorType = "";
@@ -65,10 +60,7 @@ private _mirror = _mirrorType createVehicle [0,0,0];
 _mirror setPosATL getPosATL _unit;
 _mirror attachTo [_unit, _mirrorCoords];
 
-// 创建后默认隐藏，等待条件满足再显示
-// hidden by default after creation, wait for conditions to be met before displaying
 _mirror hideObject true;
-_mirror hideObjectGlobal true;
 
 _unit setVariable ["hatg_mirror", _mirror, true];
 _unit setVariable ["hatg_mirror_visible", false, true]; 

--- a/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
@@ -13,6 +13,9 @@
     Dependencies:
         hatg_setting_simple_object <BOOL>
 
+        _unit variables:
+        > "hatg_mirror_visible" <OBJECT>
+
     Scope:
         Local, Remote* (?)
     
@@ -35,9 +38,8 @@ if (_unit isEqualTo ObjNull) exitWith {false};
 
 private _mirror = [_unit] call HATG_fnc_getMirror;
 
-
 if !(isNull _mirror) exitWith {
-    _mirror hideObject false;
+    _mirror hideObjectGlobal false;
     _unit setVariable ["hatg_mirror_visible", true, true];
     if (isPlayer _unit) then { [_unit] call HATG_fnc_handleDisplayText; };
     _mirror
@@ -60,7 +62,7 @@ private _mirror = _mirrorType createVehicle [0,0,0];
 _mirror setPosATL getPosATL _unit;
 _mirror attachTo [_unit, _mirrorCoords];
 
-_mirror hideObject true;
+_mirror hideObjectGlobal true;
 
 _unit setVariable ["hatg_mirror", _mirror, true];
 _unit setVariable ["hatg_mirror_visible", false, true]; 

--- a/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_createMirror.sqf
@@ -34,8 +34,20 @@ params [
 if (_unit isEqualTo ObjNull) exitWith {false};
 
 private _mirror = [_unit] call HATG_fnc_getMirror;
-if (_mirror isNotEqualTo ObjNull) exitWith {false};
 
+
+// mirror 已存在 → 直接显示并退出，不重复创建
+// hidden by default after creation, wait for conditions to be met before displaying
+if !(isNull _mirror) exitWith {
+    _mirror hideObject false;
+    _mirror hideObjectGlobal false;
+    _unit setVariable ["hatg_mirror_visible", true, true];
+    if (isPlayer _unit) then { [_unit] call HATG_fnc_handleDisplayText; };
+    _mirror
+};
+
+// mirror 不存在 → 创建
+// hidden by default after creation, wait for conditions to be met before displaying
 [format["Creating a mirror for %1 (ATL: %2)", name _unit, getPosATL _unit], 1, _fnc_scriptName] call HATG_fnc_log;
 
 private _mirrorType = "";
@@ -53,7 +65,13 @@ private _mirror = _mirrorType createVehicle [0,0,0];
 _mirror setPosATL getPosATL _unit;
 _mirror attachTo [_unit, _mirrorCoords];
 
+// 创建后默认隐藏，等待条件满足再显示
+// hidden by default after creation, wait for conditions to be met before displaying
+_mirror hideObject true;
+_mirror hideObjectGlobal true;
+
 _unit setVariable ["hatg_mirror", _mirror, true];
+_unit setVariable ["hatg_mirror_visible", false, true]; 
 
 if (isPlayer _unit) then {
     [_unit] call HATG_fnc_handleDisplayText;

--- a/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
@@ -39,8 +39,24 @@ if (_mirror isEqualTo ObjNull) exitWith {false}; // if mirror is still ObjNull t
 
 [format["Deleting a mirror at position (ATL: %1)", getPosATL _mirror], 1, _fnc_scriptName] call HATG_fnc_log;
 
-deleteVehicle _mirror;
-_unit setVariable ["hatg_mirror", ObjNull, true];
+// //deleteVehicle _mirror;
+// _mirror hideObject true;
+// _mirror hideObjectGlobal true;
+// //_unit setVariable ["hatg_mirror", ObjNull, true];
+
+// 检查 toggle 状态：如果开启，真正删除 mirror；否则只是隐藏
+// heck the toggle state: if on, permanently delete the mirror; otherwise, only hide it.
+private _toggle = ["hatg_mirror_toggle", false, _unit] call HATG_fnc_getVariable;
+if (_toggle) then {
+    deleteVehicle _mirror;
+    _unit setVariable ["hatg_mirror", ObjNull, true];
+    //_unit setVariable ["hatg_mirror_visible", false, true];
+    ["Mirror deleted due to toggle", 1, _fnc_scriptName] call HATG_fnc_log;
+} else {
+    _mirror hideObject true;
+    _mirror hideObjectGlobal true;
+    _unit setVariable ["hatg_mirror_visible", false, true];
+};
 
 if (isPlayer _unit) then {
     [_unit] call HATG_fnc_handleDisplayText;

--- a/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
@@ -39,22 +39,13 @@ if (_mirror isEqualTo ObjNull) exitWith {false}; // if mirror is still ObjNull t
 
 [format["Deleting a mirror at position (ATL: %1)", getPosATL _mirror], 1, _fnc_scriptName] call HATG_fnc_log;
 
-// //deleteVehicle _mirror;
-// _mirror hideObject true;
-// _mirror hideObjectGlobal true;
-// //_unit setVariable ["hatg_mirror", ObjNull, true];
-
-// 检查 toggle 状态：如果开启，真正删除 mirror；否则只是隐藏
-// heck the toggle state: if on, permanently delete the mirror; otherwise, only hide it.
 private _toggle = ["hatg_mirror_toggle", false, _unit] call HATG_fnc_getVariable;
 if (_toggle) then {
     deleteVehicle _mirror;
     _unit setVariable ["hatg_mirror", ObjNull, true];
-    //_unit setVariable ["hatg_mirror_visible", false, true];
     ["Mirror deleted due to toggle", 1, _fnc_scriptName] call HATG_fnc_log;
 } else {
     _mirror hideObject true;
-    _mirror hideObjectGlobal true;
     _unit setVariable ["hatg_mirror_visible", false, true];
 };
 

--- a/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
+++ b/hatg/addons/functions/functions/mirror/fn_deleteMirror.sqf
@@ -4,13 +4,16 @@
     
     Description:
         Deletes _mirror and removes it from the _unit namespace
+        (As of 19/07/2026 DD/MM/YY) hides the mirror instead of deleting it
     
     Params:
         _unit <OBJECT> <Default: ObjNull>
         _mirror <OBJECT> <Default: ObjNull>
     
     Dependencies:
-        N/A
+        _unit variables:
+        > "hatg_mirror_toggle" <OBJECT>
+        > "hatg_mirror_visible" <OBJECT>
 
     Scope:
         Local, Remote
@@ -37,7 +40,7 @@ if (_mirror isEqualTo ObjNull) then {
 if (_unit isEqualTo ObjNull) exitWith {false};
 if (_mirror isEqualTo ObjNull) exitWith {false}; // if mirror is still ObjNull then we can assume it does not exist
 
-[format["Deleting a mirror at position (ATL: %1)", getPosATL _mirror], 1, _fnc_scriptName] call HATG_fnc_log;
+[format["Hiding a mirror at position (ATL: %1)", getPosATL _mirror], 1, _fnc_scriptName] call HATG_fnc_log;
 
 private _toggle = ["hatg_mirror_toggle", false, _unit] call HATG_fnc_getVariable;
 if (_toggle) then {
@@ -45,7 +48,7 @@ if (_toggle) then {
     _unit setVariable ["hatg_mirror", ObjNull, true];
     ["Mirror deleted due to toggle", 1, _fnc_scriptName] call HATG_fnc_log;
 } else {
-    _mirror hideObject true;
+    _mirror hideObjectGlobal true;
     _unit setVariable ["hatg_mirror_visible", false, true];
 };
 

--- a/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
+++ b/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
@@ -28,8 +28,9 @@ if (_mirrorToggled) then {
     _displayImage = QPATHTOFOLDER(data\ui\disabled_ca.paa);
 };
 
-
-if ((_unit getVariable ["hatg_mirror_visible", false]) && {!(isNull (_unit getVariable ["hatg_mirror", objNull]))}) then {
+private _mirror = [_unit] call HATG_fnc_getMirror;
+private _mirrorVisible = ["hatg_mirror_visible", false, _unit] call HATG_fnc_getVariable;
+if (_mirrorVisible && {!(isNull _mirror)}) then {
     _colour = _displayColourHidden;
     _statusText = localize "$STR_HATG_Hidden";
     _displayImage = QPATHTOFOLDER(data\ui\hidden_ca.paa);

--- a/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
+++ b/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
@@ -28,14 +28,7 @@ if (_mirrorToggled) then {
     _displayImage = QPATHTOFOLDER(data\ui\disabled_ca.paa);
 };
 
-//if (["hatg_mirror", ObjNull, _unit] call HATG_fnc_getVariable isNotEqualTo ObjNull) then {
-//    _colour = _displayColourHidden;
-//    _statusText = localize "$STR_HATG_Hidden";
-//    _displayImage = QPATHTOFOLDER(data\ui\hidden_ca.paa);
-//};
 
-// 以下是修改内容
-// The following is the modified content
 if ((_unit getVariable ["hatg_mirror_visible", false]) && {!(isNull (_unit getVariable ["hatg_mirror", objNull]))}) then {
     _colour = _displayColourHidden;
     _statusText = localize "$STR_HATG_Hidden";

--- a/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
+++ b/hatg/addons/gui/functions/display/fn_handleDisplayText.sqf
@@ -28,7 +28,15 @@ if (_mirrorToggled) then {
     _displayImage = QPATHTOFOLDER(data\ui\disabled_ca.paa);
 };
 
-if (["hatg_mirror", ObjNull, _unit] call HATG_fnc_getVariable isNotEqualTo ObjNull) then {
+//if (["hatg_mirror", ObjNull, _unit] call HATG_fnc_getVariable isNotEqualTo ObjNull) then {
+//    _colour = _displayColourHidden;
+//    _statusText = localize "$STR_HATG_Hidden";
+//    _displayImage = QPATHTOFOLDER(data\ui\hidden_ca.paa);
+//};
+
+// 以下是修改内容
+// The following is the modified content
+if ((_unit getVariable ["hatg_mirror_visible", false]) && {!(isNull (_unit getVariable ["hatg_mirror", objNull]))}) then {
     _colour = _displayColourHidden;
     _statusText = localize "$STR_HATG_Hidden";
     _displayImage = QPATHTOFOLDER(data\ui\hidden_ca.paa);


### PR DESCRIPTION
# What purpose does this PR serve?
1. [ ] Bug
2. [*] Change
3. [ ] Miscellaneous

## What have you changed (In a short summary).
Details:Change the mirror's state-switching from createVehicle/deleteVehicle to hideObject/hideObjectGlobal operations.

### Why was this change necessary?
Details:resolve the third-person camera collision issues

### Does this pull request change core HATG functionality?
1. [ ] No
2. [*] Yes

**If yes, what core functionality does it change and why?**

**[HATG Automated Testing Result](https://github.com/SilenceIsFatto/HATG/blob/main/hatg/addons/functions/functions/debug/fn_batchTesting.sqf):**

```
Paste Below
```

## Does this PR resolve any open issues?
1. [ ] No
2. [ ] Yes

***If applicable, fill out below.***

This PR closes #ISSUENUMBER

## Is any extra work required or advised?

1. [ ] No
2. [ ] Yes (Explain below)

Details: